### PR TITLE
Removed duplicate declaration of $dashboard_config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,7 +108,6 @@ class dashboard (
   $passenger                = $dashboard::params::passenger,
   $mysql_package_provider   = $dashboard::params::mysql_package_provider,
   $ruby_mysql_package       = $dashboard::params::ruby_mysql_package,
-  $dashboard_config         = $dashboard::params::dashboard_config,
   $dashboard_root           = $dashboard::params::dashboard_root,
   $rack_version             = $dashboard::params::rack_version,
   $dashboard_workers_start  = $dashboard::params::dashboard_workers_start,


### PR DESCRIPTION
This was throwing "Error: The parameter 'dashboard_config' is declared more than once in the parameter list" on compilation 